### PR TITLE
Add caching for Bumblebee models in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ env:
   otp: "26.2.2"
   elixir: "1.16.1"
   MIX_ENV: test
+  BUMBLEBEE_CACHE_DIR: ~/.cache/bumblebee
 
 jobs:
   main:
@@ -63,3 +64,9 @@ jobs:
 
       - name: Run tests
         run: mix test --warnings-as-errors
+
+      - name: Cache Bumblebee models
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.BUMBLEBEE_CACHE_DIR }}
+          key: ${{ runner.os }}-bumblebee

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-
 
+      - name: Cache Bumblebee models
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.BUMBLEBEE_CACHE_DIR }}
+          key: ${{ runner.os }}-bumblebee
+
       - name: Install mix dependencies
         run: mix deps.get --check-locked
 
@@ -64,9 +70,3 @@ jobs:
 
       - name: Run tests
         run: mix test --warnings-as-errors
-
-      - name: Cache Bumblebee models
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.BUMBLEBEE_CACHE_DIR }}
-          key: ${{ runner.os }}-bumblebee


### PR DESCRIPTION
I decided that model cache should not depend on OTP/Elixir versions, since Huggingface model params/configs should not depend on that, but if there's something I am missing there please do say