### PR TITLE
Add simple fragmentation scheme

### DIFF
--- a/lib/mix/tasks/search.add.ex
+++ b/lib/mix/tasks/search.add.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Search.Add do
   alias Search.HexClient
 
   @moduledoc """
-  Usage: mix #{Mix.Task.task_name(__MODULE__)} <PACKAGE> [<VERSION>]
+  Usage: mix #{Mix.Task.task_name(__MODULE__)} <PACKAGE> [version:<VERSION>] [max_size:<MAX_SIZE>]
 
   Fetches the documentation for the given package from Hex. Does not embed it yet.
 
@@ -17,21 +17,44 @@ defmodule Mix.Tasks.Search.Add do
 
   @impl Mix.Task
   def run(args) do
-    [package | args_tail] = args
+    [package_name | args_tail] = args
 
-    package_or_release =
-      case args_tail do
-        [version] ->
-          version = Version.parse!(version)
-          %HexClient.Release{package_name: package, version: version}
-
-        [] ->
-          package
-      end
-
-    case Packages.add_package(package_or_release) do
-      {:ok, package} -> Mix.shell().info("Package #{package.name}@#{package.version} added.")
+    with {:ok, args} <- parse_args(args_tail, []),
+         version = Keyword.get(args, :version),
+         fragmentation_opts = Keyword.take(args, [:max_size]),
+         package_or_release = package_or_release(package_name, version),
+         {:ok, package} <-
+           Packages.add_package(package_or_release, fragmentation_opts: fragmentation_opts) do
+      Mix.shell().info("Package #{package.name}@#{package.version} added.")
+    else
       {:error, err} -> Mix.shell().error("Error: #{err}")
+    end
+  end
+
+  defp package_or_release(package_name, nil), do: package_name
+
+  defp package_or_release(package_name, version) do
+    %HexClient.Release{package_name: package_name, version: version}
+  end
+
+  defp parse_args([], acc), do: {:ok, acc}
+
+  defp parse_args([arg | args_tail], acc) do
+    case arg do
+      "version:" <> version ->
+        case Version.parse(version) do
+          {:ok, version} -> parse_args(args_tail, Keyword.put(acc, :version, version))
+          :error -> {:error, ~c(Could not parse the "version" arg value)}
+        end
+
+      "max_size:" <> max_size ->
+        case Integer.parse(max_size) do
+          {max_size, ""} -> parse_args(args_tail, Keyword.put(acc, :max_size, max_size))
+          _ -> {:error, ~c(Could not parse the "max_size" arg value)}
+        end
+
+      _ ->
+        {:error, ~c(Unknown argument: "#{arg}")}
     end
   end
 end

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -9,7 +9,10 @@ defmodule Search.FragmentationScheme do
   * `:max_size` - maximum byte_size of the output binaries. The output binaries may have size less or equal to that
     value, which also should guarantee the sequence length after tokenization will be bounded by this value.
   """
-  def split(text, opts \\ []) when is_binary(text) do
+  def split(text, opts \\ [])
+  def split("", _opts), do: []
+
+  def split(text, opts) when is_binary(text) do
     case Keyword.get(opts, :max_size) do
       nil -> [text]
       max_size -> do_split(text, [], max_size)
@@ -22,10 +25,9 @@ defmodule Search.FragmentationScheme do
 
   defp do_split(text, acc, max_size) do
     # capture the next word along with trailing whitespace and leading whitespace, if any
-    next_word =
-      (Regex.run(~r/^([\s]*[^\s]+\s+)[^\s]*/, text) ||
-         [text])
-      |> Enum.min_by(&byte_size/1)
+    [next_word] =
+      Regex.run(~r/^([\s]*[^\s]+\s+)[^\s]*/, text, capture: :all_but_first) ||
+        [text]
 
     word_chunks =
       if byte_size(next_word) > max_size do

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -24,6 +24,9 @@ defmodule Search.FragmentationScheme do
     end
   end
 
+  @doc """
+  Recreates the original text from a list of chunks.
+  """
   def recombine(chunks), do: Enum.join(chunks)
 
   defp split_binary([], ""), do: []

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -19,7 +19,7 @@ defmodule Search.FragmentationScheme do
 
       max_size ->
         text
-        |> compute_splits({0, 0}, 0, max_size, [])
+        |> compute_splits(max_size, 0, nil, [])
         |> split_binary(text)
     end
   end
@@ -33,120 +33,33 @@ defmodule Search.FragmentationScheme do
     [chunk | split_binary(splits_tail, rest)]
   end
 
-  defp compute_splits("", {0, 0}, 0, _max_size, acc), do: Enum.reverse(acc)
-
-  defp compute_splits("", {chunk_size, trailing_whitespace}, next_word, max_size, acc) do
-    if chunk_size + trailing_whitespace + next_word <= max_size do
-      compute_splits("", {0, 0}, 0, max_size, [chunk_size + trailing_whitespace + next_word | acc])
-    else
-      compute_splits("", {0, 0}, 0, max_size, [next_word, chunk_size + trailing_whitespace | acc])
-    end
-  end
+  defp compute_splits("", _, size, _, sizes), do: Enum.reverse(sizes, [size])
 
   defp compute_splits(
-         text,
-         {current_chunk_size, trailing_whitespace_size},
-         next_word_size,
+         string,
          max_size,
-         acc
+         size,
+         size_until_word,
+         sizes
        ) do
-    {graph, text} = String.next_grapheme(text)
-    graph_size = byte_size(graph)
-    whole_chunk_size = current_chunk_size + trailing_whitespace_size
+    {grapheme, string} = String.next_grapheme(string)
+    grapheme_size = byte_size(grapheme)
 
-    if graph =~ ~r/\s/ do
-      # graph is whitespace
-      if next_word_size == 0 do
-        # we are still building the current chunk
-        if whole_chunk_size + graph_size <= max_size do
-          # we can append the whitespace graph to the current chunk
-          compute_splits(
-            text,
-            {current_chunk_size, trailing_whitespace_size + graph_size},
-            0,
-            max_size,
-            acc
-          )
-        else
-          # we have to push the current chunk to the accumulator and start building the next one
-          compute_splits(text, {0, graph_size}, 0, max_size, [whole_chunk_size | acc])
-        end
+    if size + grapheme_size > max_size do
+      if size_until_word do
+        # Split before the current unfinished word
+        next = size - size_until_word
+        compute_splits(string, max_size, next + grapheme_size, nil, [size_until_word | sizes])
       else
-        # we are currently building a possible extension to the current chunk
-        cond do
-          whole_chunk_size + next_word_size + graph_size <= max_size ->
-            # both the next word and the whitespace grapheme after it can fit within the max_size
-            compute_splits(
-              text,
-              {
-                whole_chunk_size + next_word_size,
-                graph_size
-              },
-              0,
-              max_size,
-              acc
-            )
-
-          whole_chunk_size + next_word_size <= max_size ->
-            # the next word can fit, but the whitespace grapheme after it cannot - the whitespace becomes the trailing
-            # whitespace of the next chunk
-            compute_splits(
-              text,
-              {0, graph_size},
-              0,
-              max_size,
-              [whole_chunk_size + next_word_size | acc]
-            )
-
-          true ->
-            # current chunk cannot be extended, the next word becomes the current word
-            compute_splits(text, {next_word_size, graph_size}, 0, max_size, [
-              whole_chunk_size | acc
-            ])
-        end
+        # The current chunk has a single word, just split it
+        compute_splits(string, max_size, grapheme_size, nil, [size | sizes])
       end
     else
-      # graph is not whitespace
-      if next_word_size == 0 do
-        # we are building the current chunk
-        cond do
-          trailing_whitespace_size == 0 && current_chunk_size + graph_size <= max_size ->
-            # we are building the current word, so we append the grapheme to the word being built
-            compute_splits(text, {current_chunk_size + graph_size, 0}, 0, max_size, acc)
-
-          whole_chunk_size + graph_size <= max_size ->
-            # the current word ended with whitespace, so we start building the next word candidate for extension
-            compute_splits(
-              text,
-              {current_chunk_size, trailing_whitespace_size},
-              graph_size,
-              max_size,
-              acc
-            )
-
-          true ->
-            # the current word either has to be sliced in half, or the current chunk ends with whitespace,
-            # so we can just push the current chunk onto the accumulator
-            compute_splits(text, {graph_size, 0}, 0, max_size, [whole_chunk_size | acc])
-        end
-      else
-        # we are building the next word candidate
-        if whole_chunk_size + next_word_size + graph_size <= max_size do
-          # we can continue building the next word
-          compute_splits(
-            text,
-            {current_chunk_size, trailing_whitespace_size},
-            next_word_size + graph_size,
-            max_size,
-            acc
-          )
-        else
-          # the next word is too long to extend the current chunk
-          compute_splits(text, {next_word_size + graph_size, 0}, 0, max_size, [
-            whole_chunk_size | acc
-          ])
-        end
-      end
+      new_size = size + grapheme_size
+      size_until_word = if whitespace?(grapheme), do: new_size, else: size_until_word
+      compute_splits(string, max_size, new_size, size_until_word, sizes)
     end
   end
+
+  defp whitespace?(grapheme), do: grapheme =~ ~r/\s/
 end

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -20,17 +20,17 @@ defmodule Search.FragmentationScheme do
       max_size ->
         text
         |> compute_splits({0, 0}, 0, max_size, [])
-        |> split_binary(0, text, [])
+        |> split_binary(text)
     end
   end
 
   def recombine(chunks), do: Enum.join(chunks)
 
-  defp split_binary([], _start_idx, _binary, acc), do: Enum.reverse(acc)
+  defp split_binary([], ""), do: []
 
-  defp split_binary([split_size | splits_tail], start_idx, binary, acc) do
-    current_part = binary_slice(binary, start_idx, split_size)
-    split_binary(splits_tail, start_idx + split_size, binary, [current_part | acc])
+  defp split_binary([split_size | splits_tail], string) do
+    <<chunk::binary-size(^split_size), rest::binary>> = string
+    [chunk | split_binary(splits_tail, rest)]
   end
 
   defp compute_splits("", {0, 0}, 0, _max_size, acc), do: Enum.reverse(acc)

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -1,0 +1,74 @@
+defmodule Search.FragmentationScheme do
+  @doc """
+  Splits a binary into multiple binaries that satisfy limitations specified by opts.
+
+  If possible, splits the text on whitespace to preserve words. If that is impossible, splits text in between graphemes.
+
+  Supported options:
+
+  * `:max_size` - maximum byte_size of the output binaries. The output binaries may have size less or equal to that
+    value, which also should guarantee the sequence length after tokenization will be bounded by this value.
+  """
+  def split(text, opts \\ []) when is_binary(text) do
+    case Keyword.get(opts, :max_size) do
+      nil -> [text]
+      max_size -> do_split(text, [], max_size)
+    end
+  end
+
+  defp do_split("", acc, _max_size), do: Enum.reverse(acc)
+
+  defp do_split(text, acc, max_size) do
+    # capture the next word along with trailing whitespace and leading whitespace, if any
+    next_word =
+      Regex.run(~r/^([\s]*[^\s]+\s+)[^\s]*/, text)
+
+    next_word =
+      if is_nil(next_word) do
+        text
+      else
+        Enum.min_by(next_word, &byte_size/1)
+      end
+
+    word_chunks =
+      if byte_size(next_word) > max_size do
+        split_word("", next_word, [], max_size)
+      else
+        [next_word]
+      end
+
+    next_text = binary_slice(text, byte_size(next_word)..-1//1)
+
+    case {word_chunks, acc} do
+      {_, []} ->
+        do_split(next_text, word_chunks, max_size)
+
+      {[single_word], [acc_head | acc_tail]} ->
+        # we can try extending the last word in accumulator
+        if byte_size(acc_head) + byte_size(single_word) <= max_size do
+          do_split(next_text, [acc_head <> single_word | acc_tail], max_size)
+        else
+          do_split(next_text, [single_word | acc], max_size)
+        end
+
+      _ ->
+        # the word had to be split into chunks; there is no need to extend the last word in accumulator
+        do_split(next_text, word_chunks ++ acc, max_size)
+    end
+  end
+
+  defp split_word("", "", acc, _max_size), do: acc
+  defp split_word(chunk, "", acc, _max_size), do: [chunk | acc]
+
+  defp split_word(current_chunk, word_rest, acc, max_size) do
+    {next_graph, word_rest} = String.next_grapheme(word_rest)
+
+    if byte_size(current_chunk) + byte_size(next_graph) <= max_size do
+      # we can continue building the current chunk of the word
+      split_word(current_chunk <> next_graph, word_rest, acc, max_size)
+    else
+      # the next grapheme would bring the chunk over the max size, push to accumulator
+      split_word(next_graph, word_rest, [current_chunk | acc], max_size)
+    end
+  end
+end

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -21,14 +21,9 @@ defmodule Search.FragmentationScheme do
   defp do_split(text, acc, max_size) do
     # capture the next word along with trailing whitespace and leading whitespace, if any
     next_word =
-      Regex.run(~r/^([\s]*[^\s]+\s+)[^\s]*/, text)
-
-    next_word =
-      if is_nil(next_word) do
-        text
-      else
-        Enum.min_by(next_word, &byte_size/1)
-      end
+      (Regex.run(~r/^([\s]*[^\s]+\s+)[^\s]*/, text) ||
+         [text])
+      |> Enum.min_by(&byte_size/1)
 
     word_chunks =
       if byte_size(next_word) > max_size do

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -16,6 +16,8 @@ defmodule Search.FragmentationScheme do
     end
   end
 
+  def recombine(chunks), do: Enum.join(chunks)
+
   defp do_split("", acc, _max_size), do: Enum.reverse(acc)
 
   defp do_split(text, acc, max_size) do

--- a/lib/search/fragmentation_scheme.ex
+++ b/lib/search/fragmentation_scheme.ex
@@ -38,13 +38,7 @@ defmodule Search.FragmentationScheme do
 
   defp compute_splits("", _, size, _, sizes), do: Enum.reverse(sizes, [size])
 
-  defp compute_splits(
-         string,
-         max_size,
-         size,
-         size_until_word,
-         sizes
-       ) do
+  defp compute_splits(string, max_size, size, size_until_word, sizes) do
     {grapheme, string} = String.next_grapheme(string)
     grapheme_size = byte_size(grapheme)
 

--- a/lib/search/hex_client.ex
+++ b/lib/search/hex_client.ex
@@ -5,7 +5,7 @@ defmodule Search.HexClient do
 
   def get_releases(package_name) when is_binary(package_name) do
     case get("packages/#{package_name}") do
-      {:ok, %{status: 200, body: releases}} ->
+      {:ok, %{status: 200, body: %{releases: releases}}} ->
         res =
           for %{version: version} <- releases do
             %HexClient.Release{

--- a/lib/search/packages.ex
+++ b/lib/search/packages.ex
@@ -17,7 +17,6 @@ defmodule Search.Packages do
   def add_package(package_name, opts) when is_binary(package_name) do
     case HexClient.get_releases(package_name) do
       {:ok, releases} ->
-
         latest = HexClient.Release.latest(releases)
         add_package(latest, opts)
 

--- a/lib/search/packages.ex
+++ b/lib/search/packages.ex
@@ -1,5 +1,6 @@
 defmodule Search.Packages do
   import Ecto.Query, warn: false
+  alias Search.FragmentationScheme
   alias Search.Repo
 
   alias Search.Packages.{Package, DocItem, DocFragment}
@@ -11,19 +12,27 @@ defmodule Search.Packages do
   If given a package name, adds the latest version of the package to the app. If given a `%HexClient.Release{}` adds
   the specified release. Does not embed it yet.
   """
-  def add_package(package_name) when is_binary(package_name) do
+  def add_package(name_or_release, opts \\ [])
+
+  def add_package(package_name, opts) when is_binary(package_name) do
     case HexClient.get_releases(package_name) do
       {:ok, releases} ->
+
         latest = HexClient.Release.latest(releases)
-        add_package(latest)
+        add_package(latest, opts)
 
       err ->
         err
     end
   end
 
-  def add_package(%HexClient.Release{package_name: package_name, version: version} = release) do
+  def add_package(
+        %HexClient.Release{package_name: package_name, version: version} = release,
+        opts
+      ) do
     version = Version.to_string(version)
+
+    fragmentation_opts = Keyword.get(opts, :fragmentation_opts, [])
 
     with {:ok, docs} <- HexClient.get_docs_tarball(release),
          {:ok, search_data} <- ExDocParser.extract_search_data(docs) do
@@ -43,25 +52,46 @@ defmodule Search.Packages do
           |> Ecto.Changeset.put_assoc(:doc_items, [])
 
         with {:ok, package} <- Repo.insert_or_update(package),
-             :ok <- create_items_from_package(package, search_data) do
+             :ok <- create_items_from_package(package, search_data, fragmentation_opts) do
           {:ok, package}
         end
       end)
     end
   end
 
-  defp create_items_from_package(%Package{} = _package, []), do: :ok
+  defp create_items_from_package(%Package{} = _package, [], _fragmentation_opts), do: :ok
 
-  defp create_items_from_package(%Package{} = package, [search_data_head | search_data_tail]) do
+  defp create_items_from_package(
+         %Package{} = package,
+         [search_data_head | search_data_tail],
+         fragmentation_opts
+       ) do
     %{"doc" => doc, "title" => title, "ref" => ref, "type" => type} = search_data_head
 
     with {:ok, item} <-
-           create_doc_item(package, %{doc: doc, title: title, ref: ref, type: type}),
-         {:ok, _fragment} <-
-           create_doc_fragment(item, %{
-             text: "# #{title}\n\n#{doc}"
-           }) do
-      create_items_from_package(package, search_data_tail)
+           create_doc_item(package, %{title: title, ref: ref, type: type}),
+         fragments =
+           doc
+           |> FragmentationScheme.split(fragmentation_opts)
+           |> Enum.with_index(),
+         {:ok, _fragments} <-
+           create_doc_fragments_from_binaries(item, fragments, []) do
+      create_items_from_package(package, search_data_tail, fragmentation_opts)
+    end
+  end
+
+  defp create_doc_fragments_from_binaries(_doc_item, [], acc), do: {:ok, acc}
+
+  defp create_doc_fragments_from_binaries(doc_item, [{text, order} | texts_tail], acc) do
+    case create_doc_fragment(doc_item, %{
+           text: text,
+           order: order
+         }) do
+      {:ok, fragment} ->
+        create_doc_fragments_from_binaries(doc_item, texts_tail, [fragment | acc])
+
+      {:error, _} = err ->
+        err
     end
   end
 

--- a/lib/search/packages/doc_fragment.ex
+++ b/lib/search/packages/doc_fragment.ex
@@ -5,6 +5,8 @@ defmodule Search.Packages.DocFragment do
 
   schema "doc_fragments" do
     field :text, :string
+    field :order, :integer
+
     belongs_to :doc_item, Packages.DocItem
 
     timestamps(type: :utc_datetime)
@@ -13,8 +15,8 @@ defmodule Search.Packages.DocFragment do
   @doc false
   def changeset(doc_fragment, attrs) do
     doc_fragment
-    |> cast(attrs, [:text])
+    |> cast(attrs, [:text, :order])
     |> cast_assoc(:doc_item)
-    |> validate_required([:text])
+    |> validate_required([:text, :order])
   end
 end

--- a/lib/search/packages/doc_item.ex
+++ b/lib/search/packages/doc_item.ex
@@ -7,7 +7,6 @@ defmodule Search.Packages.DocItem do
     field :type, :string
     field :title, :string
     field :ref, :string
-    field :doc, :string
     belongs_to :package, Packages.Package
     has_many :doc_fragments, Packages.DocFragment, on_replace: :delete
 
@@ -17,7 +16,7 @@ defmodule Search.Packages.DocItem do
   @doc false
   def changeset(doc_item, attrs) do
     doc_item
-    |> cast(attrs, [:ref, :type, :title, :doc])
+    |> cast(attrs, [:ref, :type, :title])
     |> cast_assoc(:package)
     |> cast_assoc(:doc_fragments)
     |> validate_required([:ref, :type, :title])

--- a/lib/search_web/controllers/page_controller.ex
+++ b/lib/search_web/controllers/page_controller.ex
@@ -42,6 +42,7 @@ defmodule SearchWeb.PageController do
         |> Stream.map(fn item ->
           doc_content =
             item.doc_fragments
+            |> Enum.sort_by(& &1.order)
             |> Enum.map(& &1.text)
             |> Search.FragmentationScheme.recombine()
 

--- a/lib/search_web/controllers/page_controller.ex
+++ b/lib/search_web/controllers/page_controller.ex
@@ -38,6 +38,15 @@ defmodule SearchWeb.PageController do
         Search.Embeddings.knn_query(embedding_model, query_tensor, k: k)
         |> Stream.map(& &1.doc_fragment.doc_item)
         |> Enum.uniq_by(& &1.id)
+        |> Search.Repo.preload(:doc_fragments)
+        |> Stream.map(fn item ->
+          doc_content =
+            item.doc_fragments
+            |> Enum.map(& &1.text)
+            |> Search.FragmentationScheme.recombine()
+
+          {item, doc_content}
+        end)
 
       render(conn, :search, items: items)
     else

--- a/lib/search_web/controllers/page_html/search.html.heex
+++ b/lib/search_web/controllers/page_html/search.html.heex
@@ -1,6 +1,4 @@
-<div :for={item <- @items} class="bg-gray-100 p-4 m-4 rounded">
+<div :for={{item, doc_content} <- @items} class="bg-gray-100 p-4 m-4 rounded">
   <p class="text-lg font-bold"><%= item.title %></p>
-  <%= if item.doc do %>
-    <%= raw(Earmark.as_html!(item.doc)) %>
-  <% end %>
+  <%= raw(Earmark.as_html!(doc_content)) %>
 </div>

--- a/priv/repo/migrations/20240411191321_create_schema.exs
+++ b/priv/repo/migrations/20240411191321_create_schema.exs
@@ -15,7 +15,6 @@ defmodule Search.Repo.Migrations.CreateSchema do
       add :ref, :string, null: false
       add :type, :string, null: false
       add :title, :string, null: false
-      add :doc, :text
       add :package_id, references("packages", on_delete: :delete_all), null: false
 
       timestamps(type: :utc_datetime)
@@ -23,6 +22,7 @@ defmodule Search.Repo.Migrations.CreateSchema do
 
     create table(:doc_fragments) do
       add :text, :text, null: false
+      add :order, :integer, null: false
       add :doc_item_id, references("doc_items", on_delete: :delete_all), null: false
 
       timestamps(type: :utc_datetime)

--- a/test/search/fragmentation_scheme_test.exs
+++ b/test/search/fragmentation_scheme_test.exs
@@ -37,9 +37,9 @@ defmodule Search.FragmentationSchemeTest do
       str = "word            other word"
 
       assert FragmentationScheme.split(str, max_size: 15) == [
-        "word           ",
-        " other word"
-      ]
+               "word           ",
+               " other word"
+             ]
     end
 
     test "when splitting along whitespace and the text starts with whitespace, the whitespace characters are prepended to the first fragment" do

--- a/test/search/fragmentation_scheme_test.exs
+++ b/test/search/fragmentation_scheme_test.exs
@@ -60,4 +60,24 @@ defmodule Search.FragmentationSchemeTest do
       ]
     end
   end
+
+  describe "recombine/1" do
+    test "recreates the original text" do
+      str = """
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+      Phasellus convallis libero at lectus vestibulum, sit amet mattis leo tempor.
+
+      Aenean pulvinar purus ac euismod accumsan.
+
+      Cras finibus risus laoreet neque condimentum, nec hendrerit justo blandit.
+
+      Sed vitae orci ut odio pellentesque cursus.
+      """
+
+      split = FragmentationScheme.split(str, max_size: 100)
+
+      assert FragmentationScheme.recombine(split) == str
+    end
+  end
 end

--- a/test/search/fragmentation_scheme_test.exs
+++ b/test/search/fragmentation_scheme_test.exs
@@ -1,0 +1,63 @@
+defmodule Search.FragmentationSchemeTest do
+  alias Search.FragmentationScheme
+  use ExUnit.Case, async: true
+
+  describe "split/2" do
+    test "when given an empty string, returns empty list" do
+      assert FragmentationScheme.split("") == []
+    end
+
+    test "when given a string which satisfies the size constraint, returns a singleton list with that string" do
+      str = "short string"
+
+      assert FragmentationScheme.split(str, max_size: 100) == [str]
+    end
+
+    test "when given a string that is too long and splitting along whitespace is possible, splits the string" do
+      str = "some words and some more words"
+
+      assert FragmentationScheme.split(str, max_size: 15) == [
+               "some words and ",
+               "some more words"
+             ]
+    end
+
+    test "when splitting along whitespace, respects non-space whitespace characters" do
+      str = "word\nword\tword\u{2003}word"
+
+      assert FragmentationScheme.split(str, max_size: 7) == [
+        "word\n",
+        "word\t",
+        "word\u{2003}",
+        "word"
+      ]
+    end
+
+    test "when splitting along whitespace and the text starts with whitespace, the whitespace characters are prepended to the first fragment" do
+      str = "    words and some more words"
+
+      assert FragmentationScheme.split(str, max_size: 15) == [
+        "    words and ",
+        "some more words"
+      ]
+    end
+
+    test "when cannot split along whitespace, splits along grapheme boundaries" do
+      str1 = "asdfghjkl"
+
+      assert FragmentationScheme.split(str1, max_size: 5) == [
+        "asdfg",
+        "hjkl"
+      ]
+
+      # the "g" has a bunch of diacritics, which means the grapheme is 4 codepoints / 7 bytes long
+      str2 = "asdfg\u{0300}\u{0322}\u{0342}hjkl"
+
+      assert FragmentationScheme.split(str2, max_size: 7) == [
+        "asdf",
+        "g\u{0300}\u{0322}\u{0342}",
+        "hjkl"
+      ]
+    end
+  end
+end

--- a/test/search/fragmentation_scheme_test.exs
+++ b/test/search/fragmentation_scheme_test.exs
@@ -26,38 +26,38 @@ defmodule Search.FragmentationSchemeTest do
       str = "word\nword\tword\u{2003}word"
 
       assert FragmentationScheme.split(str, max_size: 7) == [
-        "word\n",
-        "word\t",
-        "word\u{2003}",
-        "word"
-      ]
+               "word\n",
+               "word\t",
+               "word\u{2003}",
+               "word"
+             ]
     end
 
     test "when splitting along whitespace and the text starts with whitespace, the whitespace characters are prepended to the first fragment" do
       str = "    words and some more words"
 
       assert FragmentationScheme.split(str, max_size: 15) == [
-        "    words and ",
-        "some more words"
-      ]
+               "    words and ",
+               "some more words"
+             ]
     end
 
     test "when cannot split along whitespace, splits along grapheme boundaries" do
       str1 = "asdfghjkl"
 
       assert FragmentationScheme.split(str1, max_size: 5) == [
-        "asdfg",
-        "hjkl"
-      ]
+               "asdfg",
+               "hjkl"
+             ]
 
       # the "g" has a bunch of diacritics, which means the grapheme is 4 codepoints / 7 bytes long
       str2 = "asdfg\u{0300}\u{0322}\u{0342}hjkl"
 
       assert FragmentationScheme.split(str2, max_size: 7) == [
-        "asdf",
-        "g\u{0300}\u{0322}\u{0342}",
-        "hjkl"
-      ]
+               "asdf",
+               "g\u{0300}\u{0322}\u{0342}",
+               "hjkl"
+             ]
     end
   end
 

--- a/test/search/fragmentation_scheme_test.exs
+++ b/test/search/fragmentation_scheme_test.exs
@@ -33,6 +33,15 @@ defmodule Search.FragmentationSchemeTest do
              ]
     end
 
+    test "when splitting along whitespace, if there is too much trailing whitespace, splits in the middle of it" do
+      str = "word            other word"
+
+      assert FragmentationScheme.split(str, max_size: 15) == [
+        "word           ",
+        " other word"
+      ]
+    end
+
     test "when splitting along whitespace and the text starts with whitespace, the whitespace characters are prepended to the first fragment" do
       str = "    words and some more words"
 

--- a/test/search/packages_test.exs
+++ b/test/search/packages_test.exs
@@ -12,7 +12,8 @@ defmodule Search.PackagesTest do
       [item] = doc_items_fixture(1)
 
       valid_attrs = %{
-        text: "Some text"
+        text: "Some text",
+        order: 0
       }
 
       assert {:ok, %DocFragment{} = fragment} = Packages.create_doc_fragment(item, valid_attrs)
@@ -38,14 +39,12 @@ defmodule Search.PackagesTest do
       valid_attrs = %{
         title: "Some title",
         type: "module",
-        doc: "Some doc",
         ref: "Some ref"
       }
 
       assert {:ok, %DocItem{} = item} = Packages.create_doc_item(package, valid_attrs)
       assert item.title == valid_attrs.title
       assert item.type == valid_attrs.type
-      assert item.doc == valid_attrs.doc
       assert item.ref == valid_attrs.ref
       item = Repo.preload(item, :package)
       assert item.package.id == package.id

--- a/test/support/fixtures/packages_fixtures.ex
+++ b/test/support/fixtures/packages_fixtures.ex
@@ -24,9 +24,8 @@ defmodule Search.PackagesFixtures do
 
     for i <- 1..num_items do
       Search.Repo.insert!(%Search.Packages.DocItem{
-        title: "Module doc title",
+        title: "Module doc title #{i}",
         ref: "Test ref",
-        doc: "Text #{i}",
         type: "module",
         package: package
       })
@@ -34,11 +33,13 @@ defmodule Search.PackagesFixtures do
   end
 
   def doc_fragments_fixture(num_fragments) do
-    items = doc_items_fixture(num_fragments)
+    items =
+      doc_items_fixture(num_fragments)
 
     for item <- items do
       Search.Repo.insert!(%Search.Packages.DocFragment{
-        text: "Preprocessed text: #{item.doc}",
+        text: "Preprocessed text for #{item.title}",
+        order: 0,
         doc_item: item
       })
     end


### PR DESCRIPTION
Add basic preprocessing for the docs, which also removes the duplication of docs in the database.

The fragmentation scheme added is the simplest I could come up with that would guarantee an upper bound on sequence length while avoiding slicing inside words/graphemes.

The fragmentation also means that at the moment doc items with no documentation are not embedded, even if, say, the function name alone would be useful - this is definitely one of the things that will have to be addressed in the next steps of development.